### PR TITLE
Fixed MappingSocketAddressResolver for mapping Host <--> IP example

### DIFF
--- a/Lettuce Best Practices.md
+++ b/Lettuce Best Practices.md
@@ -79,13 +79,13 @@ We use the following map to resolve Node addresses back to the host name.
         Function<HostAndPort, HostAndPort> mappingFunction = new Function<HostAndPort, HostAndPort>() {
             @Override
             public HostAndPort apply(HostAndPort hostAndPort) {
-                InetAddress[] addresses = new InetAddress[0];
+                String cacheIP = "";
                 try {
-                    addresses = DnsResolvers.JVM_DEFAULT.resolve(host);
+                    InetAddress[] addresses = DnsResolvers.JVM_DEFAULT.resolve(host);
+                    cacheIP = addresses[0].getHostAddress();
                 } catch (UnknownHostException e) {
                     e.printStackTrace();
                 }
-                String cacheIP = addresses[0].getHostAddress();
                 HostAndPort finalAddress = hostAndPort;
 
                 if (hostAndPort.hostText.equals(cacheIP))


### PR DESCRIPTION
In the initial code, you have initialized addresses with a 0-sized array. However, if an exception occurs in the try block, the array will remain empty. Calling it after the catch block, like `String cacheIP = addresses[0].getHostAddress();`, results in a java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0.

Please consider moving the addresses initialization inside the try block, but keep the cacheIP string declaration outside.

Thanks!

BR//Oleh